### PR TITLE
changing env key to "development" & removing unnecessary react-hot-loader

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,10 +10,8 @@
     ],
 
     "env": {
-        "dev": {
-            "plugins": [
-                "react-hot-loader/babel"
-            ]
+        "development": {
+            "plugins": []
         },
         "test": {
             "plugins": [


### PR DESCRIPTION
addresses https://github.com/sapientglobalmarkets/react-mobx-seed/issues/13

I could have removed the whole "development" key of .babelrc, but since this is a seed project I thought it would be easier to leave it in for people for when then need to add something
